### PR TITLE
Fix INJECT_FACTS_AS_VARS deprecation warnings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,6 +3,6 @@ avahi_services: []
 avahi_replace_wildcards: true
 avahi_network_name: '%h'
 avahi_use_ipv6: 'no'
-avahi_allow_interfaces: "{{ ansible_default_ipv4.interface }}"
+avahi_allow_interfaces: "{{ ansible_facts['default_ipv4']['interface'] }}"
 avahi_enable_reflector: 'no'
 avahi_enable_dbus: 'yes'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,10 +1,9 @@
 ---
 - name: Include OS-specific variables.
-  ansible.builtin.include_vars: "{{ ansible_os_family }}.yml"
-- name: Install Avahi package ({{ item }})
+  ansible.builtin.include_vars: "{{ ansible_facts['os_family'] }}.yml"
+- name: Install Avahi packages
   ansible.builtin.package:
-    name: '{{ item }}'
-  with_items: '{{ avahi_packages }}'
+    name: '{{ avahi_packages }}'
 - name: Configure Avahi
   ansible.builtin.template:
     src: avahi-daemon.conf.j2
@@ -23,7 +22,7 @@
     mode: "0644"
   vars:
     avahi_service_services: '{{ item.services }}'
-  with_items: '{{ avahi_services }}'
+  loop: '{{ avahi_services }}'
   notify:
     - Restart Avahi
 - name: Ensure service is running


### PR DESCRIPTION
## Summary
- Replace top-level fact variables (`ansible_os_family`, `ansible_default_ipv4`) with `ansible_facts[]` syntax to resolve ansible-core 2.24 deprecation warnings
- Pass package list directly to `ansible.builtin.package` instead of looping with `with_items`, fixing the `'item' is undefined` template warning
- Modernize remaining `with_items` to `loop`

## Test plan
- [ ] Run `uv run molecule test` to verify default scenario passes
- [ ] Run `uv run molecule test -s check_mode` to verify check_mode scenario passes
- [ ] Confirm deprecation warnings are no longer emitted during playbook runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)