### PR TITLE
Bump min_ansible_version to 2.18

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   description: Ansible role for installing and configuring Avahi.
   license: MIT
 
-  min_ansible_version: "2.4"
+  min_ansible_version: "2.18"
 
   platforms:
     - name: Ubuntu


### PR DESCRIPTION
## Summary
- Update `min_ansible_version` from 2.4 to 2.18, the oldest currently supported ansible-core version (EOL May 2026)
- The previous minimum of 2.4 predates features the role already uses (FQCNs, `loop` keyword, `ansible_facts[]` syntax)

## Test plan
- [ ] Verify CI passes
- [ ] Confirm role installs correctly from Galaxy with the updated metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)